### PR TITLE
refactorings

### DIFF
--- a/plugin/seek.vim
+++ b/plugin/seek.vim
@@ -64,16 +64,16 @@ function! SeekJumpBack()
   endif
 endfunction
 
-:nnoremap <silent> s :<C-U>call Seek(0)<CR>
-:onoremap <silent> s :<C-U>call Seek(1)<CR>
+nnoremap <silent> s :<C-U>call Seek(0)<CR>
+onoremap <silent> s :<C-U>call Seek(1)<CR>
 " c is mnemonic for 'cut short [of the seek target]'
-:onoremap <silent> c :<C-U>call Seek(0)<CR>
-:onoremap <silent> j :<C-U>call SeekJump()<CR>
+onoremap <silent> c :<C-U>call Seek(0)<CR>
+onoremap <silent> j :<C-U>call SeekJump()<CR>
 
-:nnoremap <silent> S :<C-U>call SeekBack(0)<CR>
-:onoremap <silent> S :<C-U>call SeekBack(0)<CR>
-:onoremap <silent> C :<C-U>call SeekBack(1)<CR>
-:onoremap <silent> J :<C-U>call SeekJumpBack()<CR>
+nnoremap <silent> S :<C-U>call SeekBack(0)<CR>
+onoremap <silent> S :<C-U>call SeekBack(0)<CR>
+onoremap <silent> C :<C-U>call SeekBack(1)<CR>
+onoremap <silent> J :<C-U>call SeekJumpBack()<CR>
 
 " TODO allow remapping the keys
 "## Remapping Seek

--- a/plugin/seek.vim
+++ b/plugin/seek.vim
@@ -3,7 +3,7 @@
 " Description:   Motion for seeking to a pair of characters in the current line.
 " Author:        Vic Goldfeld <github.com/goldfeld>
 " Version:       0.2
-" ReleaseDate: 	 2013-01-26
+" ReleaseDate:   2013-01-26
 " License:       Licensed under the same terms as Vim itself.
 " ==============================================================================
 
@@ -18,17 +18,17 @@ let g:loaded_seek = 1
 function! Seek(plus)
   if v:count >= 1
     execute 'normal! '.v:count.'x'
-		startinsert
-	else
-		let c1 = getchar()
-		let c2 = getchar()
-		let line = getline('.')
-		let pos = getpos('.')[2]
-		let seek = stridx(l:line[l:pos :], nr2char(l:c1).nr2char(l:c2))
-		if l:seek != -1
-			execute 'normal! 0'.(l:pos + l:seek + a:plus).'l'
-		endif
-	endif
+    startinsert
+  else
+    let c1 = getchar()
+    let c2 = getchar()
+    let line = getline('.')
+    let pos = getpos('.')[2]
+    let seek = stridx(l:line[l:pos :], nr2char(l:c1).nr2char(l:c2))
+    if l:seek != -1
+      execute 'normal! 0'.(l:pos + l:seek + a:plus).'l'
+    endif
+  endif
 endfunction
 
 function! SeekBack(plus)
@@ -43,14 +43,14 @@ function! SeekBack(plus)
 endfunction
 
 function! SeekJump()
-	let c1 = getchar()
-	let c2 = getchar()
-	let line = getline('.')
-	let pos = getpos('.')[2]
-	let seek = stridx(l:line[l:pos :], nr2char(l:c1).nr2char(l:c2))
-	if l:seek != -1
-		execute 'normal! 0'.(l:pos + l:seek).'lviw'
-	endif
+  let c1 = getchar()
+  let c2 = getchar()
+  let line = getline('.')
+  let pos = getpos('.')[2]
+  let seek = stridx(l:line[l:pos :], nr2char(l:c1).nr2char(l:c2))
+  if l:seek != -1
+    execute 'normal! 0'.(l:pos + l:seek).'lviw'
+  endif
 endfunction
 
 function! SeekJumpBack()
@@ -82,16 +82,16 @@ endfunction
 "
 "You can change seek's default mapping in your vimrc:
 "
-"	let g:SeekForward = '\'
-"	let g:SeekBackward = '|'
+"  let g:SeekForward = '\'
+"  let g:SeekBackward = '|'
 "
-"	let g:SeekCutShortForward = '|'
-"	let g:SeekCutShortBackward = '|'
+"  let g:SeekCutShortForward = '|'
+"  let g:SeekCutShortBackward = '|'
 "
-"	let g:SeekJumpForward = '
+"  let g:SeekJumpForward = '
 "
 "
-"	<cursor>L{a}rem ipsum d{b}l{c}r sit amet.
+"  <cursor>L{a}rem ipsum d{b}l{c}r sit amet.
 "
 "[link to other plugins](http://blabla.com)
 "![animated demonstration](http://blablable.com)

--- a/plugin/seek.vim
+++ b/plugin/seek.vim
@@ -64,16 +64,35 @@ function! s:seekJumpBack()
   endif
 endfunction
 
-nnoremap <silent> s :<C-U>call <SID>seek(0)<CR>
-onoremap <silent> s :<C-U>call <SID>seek(1)<CR>
-" c is mnemonic for 'cut short [of the seek target]'
-onoremap <silent> c :<C-U>call <SID>seek(0)<CR>
-onoremap <silent> j :<C-U>call <SID>seekJump()<CR>
+silent! nnoremap <unique> <Plug>(seek-seek)
+      \ :<C-U>call <SID>seek(0)<CR>
+silent! onoremap <unique> <Plug>(seek-seek)
+      \ :<C-U>call <SID>seek(1)<CR>
+silent! onoremap <unique> <Plug>(seek-seek-cut)
+      \ :<C-U>call <SID>seek(0)<CR>
+silent! onoremap <unique> <Plug>(seek-jump)
+      \ :<C-U>call <SID>seekJump()<CR>
+silent! nnoremap <unique> <Plug>(seek-back)
+      \ :<C-U>call <SID>seekBack(0)<CR>
+silent! onoremap <unique> <Plug>(seek-back)
+      \ :<C-U>call <SID>seekBack(0)<CR>
+silent! onoremap <unique> <Plug>(seek-back-cut)
+      \ :<C-U>call <SID>seekBack(1)<CR>
+silent! onoremap <unique> <Plug>(seek-jump-back)
+      \ :<C-U>call <SID>seekJumpBack()<CR>
 
-nnoremap <silent> S :<C-U>call <SID>seekBack(0)<CR>
-onoremap <silent> S :<C-U>call <SID>seekBack(0)<CR>
-onoremap <silent> C :<C-U>call <SID>seekBack(1)<CR>
-onoremap <silent> J :<C-U>call <SID>seekJumpBack()<CR>
+if !get(g:, 'seek_no_default_key_mappings', 0)
+  nmap <silent> s <Plug>(seek-seek)
+  omap <silent> s <Plug>(seek-seek)
+  " c is mnemonic for 'cut short [of the seek target]'
+  omap <silent> c <Plug>(seek-seek)
+  omap <silent> j <Plug>(seek-jump)
+
+  nmap <silent> S <Plug>(seek-back)
+  omap <silent> S <Plug>(seek-back)
+  omap <silent> C <Plug>(seek-back-cut)
+  omap <silent> J <Plug>(seek-jump-back)
+endif
 
 " TODO allow remapping the keys
 "## Remapping Seek

--- a/plugin/seek.vim
+++ b/plugin/seek.vim
@@ -15,7 +15,7 @@ let g:loaded_seek = 1
 " TODO https://github.com/vim-scripts/InsertChar/blob/master/plugin/InsertChar.vim
 " TODO follow ignorecase and smartcase rules for alpha characters (and add to readme)
 " TODO remote yank option for the 'yc' motion
-function! Seek(plus)
+function! s:seek(plus)
   if v:count >= 1
     execute 'normal! '.v:count.'x'
     startinsert
@@ -31,7 +31,7 @@ function! Seek(plus)
   endif
 endfunction
 
-function! SeekBack(plus)
+function! s:seekBack(plus)
   let c1 = getchar()
   let c2 = getchar()
   let line = getline('.')
@@ -42,7 +42,7 @@ function! SeekBack(plus)
   endif
 endfunction
 
-function! SeekJump()
+function! s:seekJump()
   let c1 = getchar()
   let c2 = getchar()
   let line = getline('.')
@@ -53,7 +53,7 @@ function! SeekJump()
   endif
 endfunction
 
-function! SeekJumpBack()
+function! s:seekJumpBack()
   let c1 = getchar()
   let c2 = getchar()
   let line = getline('.')
@@ -64,16 +64,16 @@ function! SeekJumpBack()
   endif
 endfunction
 
-nnoremap <silent> s :<C-U>call Seek(0)<CR>
-onoremap <silent> s :<C-U>call Seek(1)<CR>
+nnoremap <silent> s :<C-U>call <SID>seek(0)<CR>
+onoremap <silent> s :<C-U>call <SID>seek(1)<CR>
 " c is mnemonic for 'cut short [of the seek target]'
-onoremap <silent> c :<C-U>call Seek(0)<CR>
-onoremap <silent> j :<C-U>call SeekJump()<CR>
+onoremap <silent> c :<C-U>call <SID>seek(0)<CR>
+onoremap <silent> j :<C-U>call <SID>seekJump()<CR>
 
-nnoremap <silent> S :<C-U>call SeekBack(0)<CR>
-onoremap <silent> S :<C-U>call SeekBack(0)<CR>
-onoremap <silent> C :<C-U>call SeekBack(1)<CR>
-onoremap <silent> J :<C-U>call SeekJumpBack()<CR>
+nnoremap <silent> S :<C-U>call <SID>seekBack(0)<CR>
+onoremap <silent> S :<C-U>call <SID>seekBack(0)<CR>
+onoremap <silent> C :<C-U>call <SID>seekBack(1)<CR>
+onoremap <silent> J :<C-U>call <SID>seekJumpBack()<CR>
 
 " TODO allow remapping the keys
 "## Remapping Seek
@@ -83,12 +83,12 @@ onoremap <silent> J :<C-U>call SeekJumpBack()<CR>
 "You can change seek's default mapping in your vimrc:
 "
 "  let g:SeekForward = '\'
-"  let g:SeekBackward = '|'
+"  let g:s:seekBackward = '|'
 "
 "  let g:SeekCutShortForward = '|'
 "  let g:SeekCutShortBackward = '|'
 "
-"  let g:SeekJumpForward = '
+"  let g:s:seekJumpForward = '
 "
 "
 "  <cursor>L{a}rem ipsum d{b}l{c}r sit amet.


### PR DESCRIPTION
these are refactorings -- this pullreq doesn't change the default behaviours of vim-seek.
- no global functions (`Seek` may already exist in other plugins)
- if `g:seek_no_default_key_mappings` is set in `~/.vimrc`, vim-seek won't remove preexisting keymappings and defined keymappings
- etc
